### PR TITLE
Fix hardcoded /lib path doesn't match CMake's lib64 output

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -58,6 +58,9 @@ fn build_opus(is_static: bool) {
 
     // Prefer Release artifacts for FFI libs regardless of Rust profile
     cfg.profile("Release");
+    // Force CMake to use 'lib' instead of 'lib64' on x86_64 Linux
+    cfg.define("CMAKE_INSTALL_LIBDIR", "lib");
+
 
     if is_static {
         cfg.define("BUILD_SHARED_LIBS", "OFF")


### PR DESCRIPTION
When building with the bundled feature on Fedora x86_64 Linux, the build fails with:

error: could not find native static library `opus`, perhaps an -L flag is missing? The library is actually built successfully, but placed in lib64/ while the build script hardcodes lib/ in the linker search path.